### PR TITLE
fix(loader): allow no options.

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -10,7 +10,7 @@ var message = '';
 
 module.exports = function(source, map) {
   this.cacheable();
-  const options = loaderUtils.getOptions(this);
+  const options = loaderUtils.getOptions(this) || {};
   let config = {
     rootElement: '[ng-app]',
     log: false


### PR DESCRIPTION
When no options or query is passed, the default `loaderContext.query` is
“” which results in `null` options.