### PR TITLE
feat(): handle multiple async modules, es6 classes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ rules: [
       {
         loader: 'angular-hot-loader',
         options: {
-          log: true
+          log: true,
+          rootElement: 'html'
         }
       },
       // Any other loaders.
@@ -75,7 +76,7 @@ See Webpack documentation:
 ### rootElement {String}
 Default: `[ng-app]`
 
-Specifies application DOM root element selector.
+Specifies application DOM root element selector. Use 'html' when boostraping your Angular app on document.
 
 ### log {Boolean}
 Default: `false`

--- a/lib/angular-hot-loader.js
+++ b/lib/angular-hot-loader.js
@@ -5,6 +5,7 @@ var hotAngular;
 
 /**
  * Angular Hot Loader.
+ * @param {Object} settings - hot loader setiings.
  */
 var HotAngular = function(settings) {
   this.ANGULAR_MODULE;

--- a/lib/angular-hot-loader.js
+++ b/lib/angular-hot-loader.js
@@ -1,9 +1,10 @@
 var toFactory = require('to-factory');
 var logger = require('./logger');
 
+var hotAngular;
+
 /**
  * Angular Hot Loader.
- * @param {Object} settings - hot loader setiings.
  */
 var HotAngular = function(settings) {
   this.ANGULAR_MODULE;
@@ -40,9 +41,9 @@ var HotAngular = function(settings) {
    */
   function isClass(fn) {
     return (typeof fn === 'function' &&
-      (/^class\s/.test(toString.call(fn)) ||
-       // babel class definition.
-      (/.*classCallCheck\(/.test(fnBody(fn)))));
+    (/^class\s/.test(toString.call(fn)) ||
+    // babel class definition.
+    (/.*classCallCheck\(/.test(fnBody(fn)))));
   }
 
   /**
@@ -62,7 +63,12 @@ var HotAngular = function(settings) {
     this.originalContent = this.element.innerHTML;
   }
 
-  document.addEventListener('DOMContentLoaded', loadHandler.bind(this), false);
+  // Module may have been lazy loaded after document load.
+  if (document.readyState === 'complete') {
+    loadHandler.call(this);
+  } else {
+    document.addEventListener('DOMContentLoaded', loadHandler.bind(this), false);
+  }
 };
 
 // Angular functions to replace
@@ -117,4 +123,11 @@ HotAngular.prototype.test = function(webpackModule) {
   return this;
 }
 
-module.exports = HotAngular;
+// HotAngular must be a singleton so the cache remains the
+// same across consecutive updates.
+module.exports = function (settings) {
+  if (!hotAngular) {
+    hotAngular = new HotAngular(settings);
+  }
+  return hotAngular;
+};

--- a/lib/interceptors/component.js
+++ b/lib/interceptors/component.js
@@ -1,47 +1,29 @@
+const transform = require('../utils/transform');
+const hasChanged = require('../utils/hasChanged');
+
 module.exports = function(name, component) {
-  var obj = component;
-  var exists = this.MODULE_CACHE[name];
-  var _that = this;
-
-  var transform = function(n, obj) {
-    if (obj.template) {
-      obj.template = function() {
-        return _that.templateCache[n];
-      };
-    }
-
-    if (obj.controller && typeof obj.controller === 'function') {
-      obj.controller = function($injector, $scope) {
-        return $injector.invoke(_that.classTransform(_that.controllerCache[n]), this, {
-          '$scope': $scope
-        });
-      };
-    }
-
-    return obj;
-  };
+  let def = component;
 
   this.logger(`COMPONENT "${name}":
     ${JSON.stringify(component)}`, 'info');
 
-  var changes = false;
+  const exists = this.MODULE_CACHE[name];
+  const changed = hasChanged.call(this, name, def);
 
-  changes = changes || JSON.stringify(obj.template) !== JSON.stringify(this.templateCache[name]);
-  if (obj.template) {
-    this.templateCache[name] = obj.template;
+  if (def.template) {
+    this.templateCache[name] = def.template;
   }
 
-  changes = changes || obj.controller + '' !== this.controllerCache[name] + '';
-  if (obj.controller) {
-    this.controllerCache[name] = obj.controller;
+  if (def.controller) {
+    this.controllerCache[name] = def.controller;
   }
 
-  if (changes && exists) {
+  if (changed && exists) {
     this.reloadState();
   }
 
   if (!exists) {
-    this.ANGULAR_MODULE.component(name, transform(name, obj));
+    this.ANGULAR_MODULE.component(name, transform.call(this, name, def));
     this.MODULE_CACHE[name] = true;
   }
 

--- a/lib/interceptors/config.js
+++ b/lib/interceptors/config.js
@@ -1,5 +1,5 @@
 module.exports = function(configFunction) {
-  this.logger(`COFIG "${this.ANGULAR_MODULE.name}"
+  this.logger(`CONFIG "${this.ANGULAR_MODULE.name}"
     ${configFunction}`, 'info');
   this.ANGULAR_MODULE.config(configFunction);
 

--- a/lib/interceptors/directive.js
+++ b/lib/interceptors/directive.js
@@ -1,59 +1,37 @@
-module.exports = function(name, d) {
-  var obj = null;
+const transform = require('../utils/transform');
+const hasChanged = require('../utils/hasChanged');
 
-  if (Array.isArray(d)) {
-    obj = d[d.length - 1]();
-  } else if (typeof d === 'function') {
-    obj = d();
+module.exports = function (name, directive) {
+  let def;
+
+  if (Array.isArray(directive)) {
+    def = directive[directive.length - 1]();
+  } else if (typeof directive === 'function') {
+    def = directive();
   } else {
     throw new Error('Malformed directive function');
   }
 
-  var exists = this.MODULE_CACHE[name];
-  var _that = this;
-
-  var transform = function(n, obj) {
-    if (obj.template) {
-      obj.template = function() {
-        return _that.templateCache[n];
-      };
-    }
-
-    if (obj.controller && typeof obj.controller === 'function') {
-      obj.controller = function($injector, $scope) {
-        return $injector.invoke(_that.classTransform(_that.controllerCache[n]), this, {
-          '$scope': $scope
-        });
-      };
-    }
-
-    return obj;
-  };
-
   this.logger(`DIRECTIVE "${name}":
     ${obj}`, 'info');
 
-  var changes = false;
+  const exists = this.MODULE_CACHE[name];
+  const changed = hasChanged.call(this, name, def);
 
-  changes = changes || JSON.stringify(obj.template) != JSON.stringify(this.templateCache[name]);
-  if (obj.template) {
-    this.templateCache[name] = obj.template;
+  if (def.template) {
+    this.templateCache[name] = def.template;
   }
 
-  changes = changes || obj.controller + '' != this.controllerCache[name] + '';
-  if (obj.controller) {
-    this.controllerCache[name] = obj.controller;
+  if (def.controller) {
+    this.controllerCache[name] = def.controller;
   }
 
-  if (changes && exists) {
+  if (exists && changed) {
     this.reloadState();
   }
 
   if (!exists) {
-    this.ANGULAR_MODULE.directive(name, function() {
-      return transform(name, obj);
-    });
-
+    this.ANGULAR_MODULE.directive(name, transform.call(this, name, def));
     this.MODULE_CACHE[name] = true;
   }
 

--- a/lib/interceptors/directive.js
+++ b/lib/interceptors/directive.js
@@ -13,7 +13,7 @@ module.exports = function (name, directive) {
   }
 
   this.logger(`DIRECTIVE "${name}":
-    ${obj}`, 'info');
+    ${def}`, 'info');
 
   const exists = this.MODULE_CACHE[name];
   const changed = hasChanged.call(this, name, def);

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -40,8 +40,7 @@ module.exports = function(source, map) {
   prependText = `
     if (module.hot) {
       module.hot.accept();
-      var hotAngularLoader = require(${JSON.stringify(require.resolve('./angular-hot-loader'))});
-      var hotAngular = new hotAngularLoader(${JSON.stringify(config)});
+      var hotAngular = require('${require.resolve('./angular-hot-loader')}')(${JSON.stringify(config)});
     }
   `;
 

--- a/lib/utils/hasChanged.js
+++ b/lib/utils/hasChanged.js
@@ -1,0 +1,29 @@
+/**
+ * Get content of all the methods in the class definition,
+ * (e.g. constructor and any other prototype methods).
+ *
+ * @param {Function} cls - Class
+ * @return {string}
+ */
+function getClassContent (cls) {
+  let content = '';
+  const props = Object.getOwnPropertyDescriptors(cls.prototype);
+  for (let prop of Object.values(props)) {
+    content += prop.value.toString();
+  }
+  return content;
+}
+
+module.exports = function (name, def) {
+  if (!this.templateCache[name]) return true;
+  const templateChanged = def.template.toString() !== this.templateCache[name].toString();
+
+  // No need to check class, if template already changed.
+  // Assuming template is smaller than controller class.
+  if (templateChanged) return true;
+
+  if (!this.controllerCache[name]) return true;
+  const controllerChanged = getClassContent(def.controller) !== getClassContent(this.controllerCache[name]);
+
+  return controllerChanged;
+};

--- a/lib/utils/hasChanged.js
+++ b/lib/utils/hasChanged.js
@@ -7,9 +7,9 @@
  */
 function getClassContent (cls) {
   let content = '';
-  const props = Object.getOwnPropertyDescriptors(cls.prototype);
-  for (let prop of Object.values(props)) {
-    content += prop.value.toString();
+  const props = Object.getOwnPropertyNames(cls.prototype);
+  for (let prop of props) {
+    content += cls.prototype[prop].toString();
   }
   return content;
 }

--- a/lib/utils/transform.js
+++ b/lib/utils/transform.js
@@ -1,0 +1,19 @@
+module.exports = function (name, def) {
+  if (def.template) {
+    def.template = () => {
+      return this.templateCache[name];
+    };
+  }
+
+  if (def.controller && typeof def.controller === 'function') {
+    def.controller = ($injector, $scope) => {
+      return $injector.invoke(
+        this.classTransform(this.controllerCache[name]),
+        this,
+        { $scope: $scope }
+      );
+    };
+  }
+
+  return def;
+};


### PR DESCRIPTION
Finally made it work :) Here are the necessary changes:

* [x] **Revert HotAngular to a singleton** as in the original repo, while supporting the settings. This is required so that the cache remains the same across multiple updates, rather than creating empty instances on every refresh.
* [x] **Identify changes in ES6 component classes.** When using ES6 classes, the component code is split into multiple prototype methods rather than the single constructor in ES5.
* [x] **Handle lazy loaded modules.** The DOMContentLoaded event may have already happened.
* [x] Add note in README for manually bootstrapped apps on the document node.