### PR TITLE
fix(transform): add missing locals into controller.

### DIFF
--- a/lib/utils/transform.js
+++ b/lib/utils/transform.js
@@ -7,11 +7,16 @@ module.exports = function (name, def) {
 
   if (def.controller && typeof def.controller === 'function') {
     const that = this;
-    def.controller = function ($injector, $scope) {
+    def.controller = function ($injector, $scope, $element, $attrs, $transclude) {
       return $injector.invoke(
         that.classTransform(that.controllerCache[name]),
         this,
-        { $scope: $scope }
+        {
+          $scope,
+          $element,
+          $attrs,
+          $transclude
+        }
       );
     };
   }


### PR DESCRIPTION
https://docs.angularjs.org/api/ng/service/$compile#-controller-

`$element`, `$attrs` and `$transclude` are locals, not providers.