### PR TITLE
chore(): remove angular npm peer dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,6 @@
     "url": "https://github.com/vitaliy-bobrov/angular-hot-loader/issues"
   },
   "homepage": "https://github.com/vitaliy-bobrov/angular-hot-loader#readme",
-  "peerDependencies": {
-    "angular": "^1.5.0"
-  },
   "devDependencies": {
     "eslint": "^3.17.1",
     "eslint-plugin-node": "^4.2.0"


### PR DESCRIPTION
Angular is not used directly in this package. Also, it may be loaded with Bower. And I believe this may actually work with Angular < 1.5?