### PR TITLE
Babel-runtime transformed classes support

### DIFF
--- a/lib/angular-hot-loader.js
+++ b/lib/angular-hot-loader.js
@@ -46,7 +46,7 @@ var HotAngular = function(settings) {
     return (typeof fn === 'function' &&
     (/^class\s/.test(toString.call(fn)) ||
     // babel class definition.
-    (/.*classCallCheck\(/.test(fnBody(fn)))));
+    (/.*classCallCheck\(?/.test(fnBody(fn)))));
   }
 
   /**


### PR DESCRIPTION
Transpiled code looks like:

```js
__WEBPACK_IMPORTED_MODULE_0_babel_runtime_helpers_classCallCheck___default()(this, ModalController);
```

So we can make initial function invocation bracket optional, to match pattern presented above. #15