### PR TITLE
Fixed "aSourceMapConsumer.eachMapping is not a function"

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -56,13 +56,15 @@ function transform(source, map) {
     logger(message, 'info');
   }
 
-  const node = new SourceNode(null, null, null, [
-    new SourceNode(null, null, this.resourcePath, prependText),
-    SourceNode.fromStringWithSourceMap(processedSource, new SourceMapConsumer(map))
-  ]).join(separator);
-  const result = node.toStringWithSourceMap();
-
-  return this.callback(null, result.code, result.map.toString());
+  this.async();
+  Promise.resolve(new SourceMapConsumer(map))
+    .then((consumer) => new SourceNode(null, null, null, [
+      new SourceNode(null, null, this.resourcePath, prependText),
+      SourceNode.fromStringWithSourceMap(processedSource, consumer)
+    ]).join(separator))
+    .then((node) => node.toStringWithSourceMap())
+    .then((result) => this.callback(null, result.code, result.map.toString()))
+    .catch((err) => this.callback(err));
 }
 
 module.exports = transform;


### PR DESCRIPTION
This fixed the issue #31.
This solution should work in Webpack 2/3/4.

I can not test this solution today, because I do not have a project on angularjs. But I will test it on work project on Monday and report the result.
